### PR TITLE
Fix Teleportante link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This was inspired by pppoe's [Circle-Counter-Down]. Thank you!
 
 [Cocoapods]: http://cocoapods.org/
 [Circle-Counter-Down]: https://github.com/pppoe/Circle-Counter-Down
-[Teleportante]: bit.ly/Teleportante
+[Teleportante]: http://bit.ly/Teleportante


### PR DESCRIPTION
The Teleportante link needed the protocol listed as it was redirecting to a subdirectory within the repo that didn't exist.
